### PR TITLE
Modernize env and add ViWiki utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,13 @@ conda activate tell
 # This step is only needed if you want to use the Jupyter notebook
 python -m ipykernel install --user --name tell --display-name "tell"
 
-# Our Pytorch uses CUDA 10.2. Ensure that CUDA_HOME points to the right
-# CUDA version. Chagne this depending on where you installed CUDA.
-export CUDA_HOME=/usr/local/cuda-10.2
 
-# We also pin the apex version, which is used for mixed precision training
-cd libs/apex
-git submodule init && git submodule update .
-pip install -v --no-cache-dir --global-option="--pyprof" --global-option="--cpp_ext" --global-option="--cuda_ext" ./
+# This environment targets CUDA 11.6. Ensure that CUDA_HOME points to the
+# correct installation.
+export CUDA_HOME=/usr/local/cuda-11.6
 
 # Install our package
-cd ../.. && python setup.py develop
+python setup.py develop
 
 # Spacy is used to calcuate some of the evaluation metrics
 spacy download en_core_web_lg

--- a/environment.yml
+++ b/environment.yml
@@ -5,30 +5,29 @@ channels:
   - conda-forge
 dependencies:
   - autopep8=1.4.4
-  - cudatoolkit=10.2.89
+  - cudatoolkit=11.6
   - cython=0.29.15
-  - ipykernel=5.1.4
-  - matplotlib=3.1.3
+  - ipykernel
+  - matplotlib
   - mypy=0.750
-  - numpy=1.17.2
-  - pip=20.0.2
-  - pillow=7.1.2
-  - pytorch=1.5.1
-  - python=3.7.4
+  - numpy
+  - pip
+  - pillow
+  - pytorch=1.12.1
+  - python=3.8
   - pyyaml=5.1.2
-  - torchvision=0.6.1
+  - torchvision=0.13.1
   - pip:
-      - allennlp==0.9.0
+      - allennlp==2.10.1
       - beautifulsoup4==4.8.2
-      - django==3.0.5
-      - djangorestframework==3.11.0
-      - django-cors-headers==3.2.1
+      - django==3.2
+      - djangorestframework==3.14.0
+      - django-cors-headers==3.13.0
       - docopt==0.6.2
       - langdetect==1.0.7
       - nltk==3.4.5
       - overrides==2.8.0
       - opencv-python==4.2.0.34
-      - Pillow==7.0.0
       - ptvsd==4.3.2
       - pudb==2019.2
       - git+git://github.com/salaniz/pycocoevalcap.git@a6b79b0fbd0f4f293634831e4e09405de2abc955
@@ -43,3 +42,4 @@ dependencies:
       - termcolor==1.1.0
       - tqdm==4.43.0
       - transformers==2.5.1
+      - facenet-pytorch

--- a/scripts/viwiki_split_converter.py
+++ b/scripts/viwiki_split_converter.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""Convert simple ViWiki JSON data into the format required by
+``ViWiki_face_ner_match.py``.
+
+Input directory must contain ``train.json``, ``val.json`` and ``test.json``.
+Each file has the structure::
+
+    {
+        "0": {
+            "image_path": "/path/to/img.jpg",
+            "paragraphs": [...],
+            "scores": [...],
+            "caption": "caption text",
+            "context": ["sentence 1", "sentence 2", ...]
+        },
+        ...
+    }
+
+This script generates ``splits.json`` and ``articles.json`` (and an empty
+``objects.json``) compatible with the ``ViWiki_face_ner`` dataset reader.  Each
+entry is assigned an ``_id`` equal to the key in the source JSON.
+Images can optionally be copied into an output directory so that they are named
+``<_id>.jpg`` as expected by the dataset reader.
+"""
+
+import argparse
+import json
+import os
+import shutil
+from typing import Dict, Tuple, List
+
+
+def load_split(path: str) -> Dict[str, dict]:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def convert_items(items: Dict[str, dict], split: str, image_out: str = None
+                   ) -> Tuple[List[dict], List[dict]]:
+    samples = []
+    articles = []
+    for sid, item in items.items():
+        sample_id = str(sid)
+        if image_out:
+            os.makedirs(image_out, exist_ok=True)
+            dst = os.path.join(image_out, f"{sample_id}.jpg")
+            if not os.path.exists(dst):
+                try:
+                    shutil.copy(item["image_path"], dst)
+                except OSError:
+                    pass
+        # Build article entry
+        article = {
+            "_id": sample_id,
+            "context": " ".join(item.get("context", [])),
+            "images": [item.get("caption", "")],
+            "web_url": "",
+            "caption_ner": [[]],
+            "context_ner": [],
+        }
+        articles.append(article)
+        # Build split sample
+        samples.append({
+            "_id": sample_id,
+            "article_id": sample_id,
+            "split": split,
+            "image_index": 0,
+        })
+    return samples, articles
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create ViWiki dataset files")
+    parser.add_argument("data_dir", help="Directory with train/val/test JSON")
+    parser.add_argument("output_dir", help="Directory to write converted files")
+    parser.add_argument("--image-out", dest="image_out", default=None,
+                        help="Optional directory to copy images")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    all_samples: List[dict] = []
+    all_articles: List[dict] = []
+
+    for split_name in ["train", "val", "test"]:
+        path = os.path.join(args.data_dir, f"{split_name}.json")
+        items = load_split(path)
+        samples, articles = convert_items(items, split_name, args.image_out)
+        all_samples.extend(samples)
+        all_articles.extend(articles)
+
+    with open(os.path.join(args.output_dir, "splits.json"), "w", encoding="utf-8") as f:
+        json.dump(all_samples, f, ensure_ascii=False, indent=2)
+
+    with open(os.path.join(args.output_dir, "articles.json"), "w", encoding="utf-8") as f:
+        json.dump(all_articles, f, ensure_ascii=False, indent=2)
+
+    # create empty objects.json for convenience
+    with open(os.path.join(args.output_dir, "objects.json"), "w", encoding="utf-8") as f:
+        json.dump([], f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tell/facenet/__init__.py
+++ b/tell/facenet/__init__.py
@@ -1,2 +1,13 @@
-from .inception_resnet_v1 import InceptionResnetV1
-from .mtcnn import MTCNN
+"""Wrapper to provide face detection and recognition models.
+
+The original project included custom implementations of MTCNN and
+InceptionResnetV1.  These are now provided by the ``facenet_pytorch``
+package which is actively maintained.  Fallback to the local versions if the
+library is not available.
+"""
+
+try:
+    from facenet_pytorch import MTCNN, InceptionResnetV1
+except Exception:  # pragma: no cover - only used when facenet_pytorch missing
+    from .inception_resnet_v1 import InceptionResnetV1
+    from .mtcnn import MTCNN


### PR DESCRIPTION
## Summary
- update environment for CUDA 11.6 and modern PyTorch
- drop apex instructions in README and update CUDA version
- use facenet-pytorch if available
- add script to convert simple ViWiki json data into the dataset reader format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'allennlp')*

------
https://chatgpt.com/codex/tasks/task_e_6858264152f88324918829d5018bc81d